### PR TITLE
from_midi is now const

### DIFF
--- a/src/data/usb_midi/usb_midi_event_packet.rs
+++ b/src/data/usb_midi/usb_midi_event_packet.rs
@@ -83,7 +83,7 @@ impl TryFrom<&[u8]> for UsbMidiEventPacket {
 
 impl UsbMidiEventPacket {
     /// Creates a packet from a MIDI message and returns it.
-    pub fn from_midi(cable: CableNumber, midi: Message) -> UsbMidiEventPacket {
+    pub const fn from_midi(cable: CableNumber, midi: Message) -> UsbMidiEventPacket {
         UsbMidiEventPacket {
             cable_number: cable,
             message: midi,


### PR DESCRIPTION
I have marked the `UsbMidiEventPacket::from_midi` as const since it is. 